### PR TITLE
4.0.1 - Bug fix

### DIFF
--- a/area_app/forms.py
+++ b/area_app/forms.py
@@ -12,11 +12,6 @@ class SignupWithNameForm(Form):
     first_name = CharField(max_length=40, label='First Name')
     last_name = CharField(max_length=40, label='Last Name')
 
-    def __init__(self, *args, **kwargs):
-        super(Form, self).__init__(*args, **kwargs)
-        #print(self.fields)
-        self.fields['password1'].help_text = 'Password must be at least 8 characters and consists of numbers and letters.'
-
     def signup(self, request, user):
         user.first_name = self.cleaned_data['first_name']
         user.last_name = self.cleaned_data['last_name']

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -26,6 +26,7 @@
     <form class="signup" id="signup_form" method="post">
         {% csrf_token %}
         {{ form|bootstrap }}
+        <p>Password must be at least 8 characters and consists of numbers and letters.</p>
         {% if redirect_field_value %}
             <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
         {% endif %}


### PR DESCRIPTION
For whatever reason, `password1` is not available when starting up the app. Just add the help_text at the bottom of the form instead of trying to override it in the class