### PR TITLE
4.0.3

### DIFF
--- a/decisions/templatetags/module_tags.py
+++ b/decisions/templatetags/module_tags.py
@@ -1,4 +1,5 @@
 from django import template
+from django.urls import reverse
 from django.templatetags import static
 
 register = template.Library()
@@ -19,6 +20,12 @@ def get_module_badge(badge_label):
 
 @register.inclusion_tag('decisions/snippets/module_link.html')
 def get_module_link(moduleObj, userObj):
+    #
+    moduleObj.display_label = "Module {0} : {1}".format(moduleObj.display_num(), moduleObj.name())
+    # Build out the url to reverse
+    to_reverse = "module{0}_{1}".format(moduleObj.num(), moduleObj.step)
+    moduleObj.display_url = reverse(to_reverse)
+
     return { 'module': moduleObj, 'user': userObj }
 
 @register.inclusion_tag('decisions/snippets/back_link.html')

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 4.0.3
+* Bug fix. module.step url needs to be reversed, otherwise it'll return a 404 when coming back to the module
+
 # 4.0.2
 * Bug fix. pop-up dialog in module 1 does not close properly due to issue with CSS. `0/cheetah1/sheet`
 * Bug fix. `decision` and `decision_as_question` not passed in when printing the results in `1/cheetah3/print`

--- a/templates/decisions/snippets/module_link.html
+++ b/templates/decisions/snippets/module_link.html
@@ -2,14 +2,12 @@
 <div class="row">
     <div class="col-xs-10 col-sm-10" style="margin-top: 0;">
     <h3>
-        {% with 'Module '|add:module.display_num|add:' : '|add:module.name as module_label %}
-            {% if module.completed_on %}
-                Module {{ module.display_num }}{{ module_label }}
-            {% else %}
-                <a href="/{{ module.num }}/{% if module.step %}{{ module.step }}{% endif %}">Module
-                    {{ module.display_num }}{{ module_label }}</a>
-            {% endif %}
-        {% endwith %}
+        {# display_url and display_label are set in decisions/templatetags/module_tags #}
+        {% if module.completed_on %}
+            {{ module.display_label }}
+        {% else %}
+            <a href="{{ module.display_url }}">{{ module.display_label }}</a>
+        {% endif %}
         (<a href="/{{ module.num }}/restart">Restart</a>)
     </h3>
     </div>


### PR DESCRIPTION
In the db, we store part of the module step name rather than the actual url.

Thus instead of `/0/cheetah1/sheet`, it'll be stored as `cheetah1_sheet`.

When coming back to the `/decisions` page, since we don't reverse that value to get the actual url, we'll end up with a 404. 

Fix is to calculate the actual url and use that